### PR TITLE
Fixed potential server attack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12316,10 +12316,9 @@
       }
     },
     "websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
-      "dev": true
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
     },
     "when": {
       "version": "3.6.4",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bower": "^1.8.8",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",
+    "websocket-extensions": "^0.1.4",
     "zone.js": "~0.10.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumped websocket-extensions from 0.1.3 to 0.1.4 to avoid a regex denial of service attack GHSA-g78m-2chm-r7qv